### PR TITLE
Allow limiting THREADS via the host's environment

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -31,7 +31,7 @@ done
 
 # Set Threads automatically
 set -x
-THREADS="$(nproc)"
+THREADS="${THREADS:-$(nproc)}"
 export THREADS
 set +x
 


### PR DESCRIPTION
Makes the THREADS variable use a pre-existing value instead of forcing all available horsepower by default.